### PR TITLE
Add typings to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mysql",
     "sqlite"
   ],
+  "typings": { "./d.ts/anydb-sql.d.ts" },
   "bugs": {
     "url": "https://github.com/doxout/anydb-sql/issues"
   },


### PR DESCRIPTION
According to [this link](http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html) the typings can be used directly from the NPM package, if specified in package.json. This PR adds support for it.